### PR TITLE
Fractional Exponent 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.0"
+          - "1.6"
           - "1"
           - "nightly"
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "Random", "SafeTestsets"]
+test = ["Test", "Random", "SafeTestsets", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulChainRules"
 uuid = "f31437dd-25a7-4345-875f-756556e6935d"
 authors = ["Sam Buercklin <sam.buercklin@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/UnitfulChainRules.jl
+++ b/src/UnitfulChainRules.jl
@@ -2,7 +2,7 @@ module UnitfulChainRules
 
 using Unitful
 using Unitful: Quantity, Units, NoDims, FreeUnits
-using ChainRulesCore: NoTangent, @scalar_rule
+using ChainRulesCore: NoTangent, @scalar_rule, @thunk
 import ChainRulesCore: rrule, frule, ProjectTo
 
 const REALCOMPLEX = Union{Real, Complex}

--- a/src/math.jl
+++ b/src/math.jl
@@ -6,3 +6,46 @@ function rrule(::typeof(abs), x::Unitful.Quantity{T,D,U}) where {T<:REALCOMPLEX,
     end
     return Ω, abs_pullback
 end
+
+# Reference from ChainRules.jl
+# https://github.com/JuliaDiff/ChainRules.jl/blob/1f4a8a9d86c79f024a911f61aa180bdc094bb8a3/src/rulesets/Base/fastmath_able.jl#L186-L200
+function rrule(::typeof(^), x::Quantity{T,D,U}, p::Number) where {T,D,U}
+    y = x^p
+    project_x = ProjectTo(x)
+    project_p = ProjectTo(p)
+    function power_pullback(dy)
+        _dx = _pow_grad_x(x, p, float(y))
+        return (
+            NoTangent(), 
+            project_x(conj(_dx) * dy),
+            # _pow_grad_p contains log, perhaps worth thunking:
+            @thunk project_p(conj(_pow_grad_p(x, p, float(y))) * dy)
+        )
+    end
+    return y, power_pullback
+end
+
+# Functions for ^ rrule above
+_pow_grad_x(x, p, y) = (p * y / x)
+function _pow_grad_x(x::Quantity{T,D,U}, p::Real, y) where {T<:Real, D, U}
+    return if !iszero(x) || p < 0
+        p * y / x
+    elseif isone(p)
+        one(y)
+    elseif iszero(p) || p > 1
+        zero(y)
+    else
+        oftype(y, Inf)
+    end
+end
+
+_pow_grad_p(x::Quantity{T,D,U}, p, y) where {T,D,U} = y * Quantity{T,D,U}(log(complex(x.val)))
+function _pow_grad_p(x::Quantity{T,D,U}, p::Real, y) where {T<:Real, D, U}
+    return if !iszero(x)
+        y * Quantity{T,D,U}(real(log(complex(x.val))))
+    elseif p > 0
+        zero(y)
+    else
+        oftype(y, NaN)
+    end
+end

--- a/test/extras.jl
+++ b/test/extras.jl
@@ -1,19 +1,20 @@
 using Unitful
 using UnitfulChainRules
 using ChainRulesCore
+using Zygote
 
 @testset "ustrip" begin
-	x = 5.0u"m"
-	Ω, pb = rrule(ustrip, x)
+    x = 5.0u"m"
+    Ω, pb = Zygote.pullback(ustrip, x)
 
-	@test Ω == 5.0
-	@test last(pb(2.0)) == 2.0/u"m"
+    @test Ω == 5.0
+    @test last(pb(2.0)) == 2.0/u"m"
 end
 
 @testset "uconvert" begin
-	x = 30.0u"°"
-	Ω, pb = rrule(uconvert, u"rad", x)
+    x = 30.0u"°"
+    Ω, pb = Zygote.pullback(x -> uconvert(u"rad",x), x)
 
-	@test Ω ≈ (π/6)u"rad"
-	@test last(pb(1.0)) ≈ π*u"rad"/180u"°"
+    @test Ω ≈ (π/6)u"rad"
+    @test last(pb(1.0)) ≈ π*u"rad"/180u"°"
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -12,3 +12,22 @@ using Zygote
     @test Ω ≈ sqrt(2)u"W"
     @test last(pb(1.0)) ≈ (1 + im)/sqrt(2)
 end
+
+@testset "^" begin
+    for p in (1/3, 1//3)
+        @testset "Real Input, $p" begin
+            x = 3.0u"W^3"
+            Ω, pb = Zygote.pullback(x -> x^p, x)
+
+            @test Ω ≈ x^p
+            @test only(pb(1.0)) ≈ p * x^(p-1)
+        end
+        @testset "Complex input, $p" begin
+            z = (3.0 + 0.0im)u"W^3"
+            Ω, pb = Zygote.pullback(z -> z^p, z)
+
+            @test Ω ≈ z^p
+            @test only(pb(1.0)) ≈ p * z^(p-1)
+        end
+    end
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -3,9 +3,11 @@ using UnitfulChainRules
 
 using ChainRulesCore
 
+using Zygote
+
 @testset "abs" begin
     z = (1 + im)u"W"
-    Ω, pb = rrule(abs, z)
+    Ω, pb = Zygote.pullback(abs, z)
 
     @test Ω ≈ sqrt(2)u"W"
     @test last(pb(1.0)) ≈ (1 + im)/sqrt(2)

--- a/test/rrules-frules-projection.jl
+++ b/test/rrules-frules-projection.jl
@@ -3,6 +3,8 @@ using UnitfulChainRules
 
 using ChainRulesCore: frule, rrule, ProjectTo, NoTangent
 
+using Zygote
+
 using Random
 rng = VERSION >= v"1.7" ? Random.Xoshiro(0x0451) : Random.MersenneTwister(0x0451)
 
@@ -50,18 +52,18 @@ end
         UT = typeof(1.0*u"W")
         x = randn(rng)
         δx = randn(rng)
-        Ω, pb = rrule(UT, x)
+        Ω, pb = Zygote.pullback(UT, x)
         @test Ω == x * u"W"
-        @test pb(δx) == (NoTangent(), δx * u"W")
+        @test only(pb(δx)) == δx * u"W"
     end
     @testset "* rrule" begin
         x = randn(rng)*u"W" 
         y = u"m"
         z = u"L"
-        Ω, pb = rrule(*, x, y, z)
+        Ω, pb = Zygote.pullback(*, x, y, z)
         @test Ω == x*y*z
         δ = randn(rng)
-        @test pb(δ) == (NoTangent(), δ*y*z, NoTangent(), NoTangent())
+        @test pb(δ) == (δ*y*z, nothing, nothing)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,7 @@ end
 @safetestset "Extras" begin
     include("./extras.jl")
 end
+
+@safetestset "Math" begin
+    include("./math.jl")
+end


### PR DESCRIPTION
Closes #10 by porting the `x^p` `rrule` from `ChainRules.jl` to `UnitfulChainRules.jl` where `x` is `Unitful.Quantity`.

Also introduces `Zygote.jl` for testing `rrule`s correctly, since previously I was just manually running the `rrule`s.

@bks-nist, do you want to verify that this works for you? Otherwise I'll just merge + tag a release in a couple days